### PR TITLE
Fix star braking distance issue (#24)

### DIFF
--- a/js/camera/camera.js
+++ b/js/camera/camera.js
@@ -108,7 +108,8 @@ class Camera {
         if (this.isCoasting) {
             for (const obj of celestialObjects) {
                 const distance = obj.distanceToShip(this);
-                const brakeDistance = obj.discoveryDistance + 40; // Start braking closer for natural approach
+                // Use separate braking distance for stars, or fall back to discovery distance + 40 for other objects
+                const brakeDistance = obj.brakingDistance ? obj.brakingDistance + 40 : obj.discoveryDistance + 40;
                 
                 if (distance < brakeDistance) {
                     const currentSpeed = Math.sqrt(this.velocityX * this.velocityX + this.velocityY * this.velocityY);

--- a/js/celestial/celestial.js
+++ b/js/celestial/celestial.js
@@ -397,6 +397,7 @@ class Star extends CelestialObject {
         const baseRadius = 80 + Math.random() * 60; // 80-140 pixels base
         this.radius = baseRadius * this.starType.sizeMultiplier;
         this.discoveryDistance = this.radius + 400;
+        this.brakingDistance = this.radius + 100; // Separate braking distance for stars
         
         // Set color from star type's color palette
         this.color = this.starType.colors[Math.floor(Math.random() * this.starType.colors.length)];
@@ -423,6 +424,7 @@ class Star extends CelestialObject {
         const baseRadius = rng.nextFloat(80, 140); // 80-140 pixels base
         this.radius = baseRadius * this.starType.sizeMultiplier;
         this.discoveryDistance = this.radius + 400;
+        this.brakingDistance = this.radius + 100; // Separate braking distance for stars
         
         // Set color from star type's color palette using seeded random
         this.color = rng.choice(this.starType.colors);


### PR DESCRIPTION
## Summary
🛠️ **Fixes issue #24**: Resolved excessive star braking distances that were disrupting space travel by decoupling braking logic from discovery distance.

## Problem
When we extended star discovery distance to `radius + 400` for improved coasting exploration (#21), the braking system automatically extended too because it used `discoveryDistance + 40`. This created:
- **Massive braking zones**: 520-580+ pixels (nearly a full screen)
- **Disrupted transit**: Ships braking when just passing near stars
- **Frustrating gameplay**: Made cruising between systems annoying instead of smooth

## Solution
**Decoupled braking from discovery** by adding a separate `brakingDistance` property:
- ✅ **Added `brakingDistance` property** to Star class (`radius + 100`)
- ✅ **Updated camera braking logic** to use the new property when available
- ✅ **Maintained backward compatibility** for planets and moons
- ✅ **Preserved intended functionality** of extended star discovery

## Results
| Object Type | Discovery Distance | Braking Distance | Status |
|-------------|-------------------|------------------|---------|
| **Stars** | radius + 400 (480-540px) | radius + 140 (180-240px) | ✅ Fixed |
| **Planets** | radius + 30 (38-50px) | radius + 70 (68-90px) | ✅ Unchanged |
| **Moons** | radius + 25 (27-30px) | radius + 65 (67-70px) | ✅ Unchanged |

## Benefits
- **🌟 Stars remain discoverable from great distances** for coasting exploration
- **🚀 Reasonable braking zones** that don't disrupt space travel
- **🪐 Planets and moons work exactly as before** (they were perfect)
- **🎮 Smooth gameplay flow restored** for exploration and navigation

## Technical Details
- **Minimal code changes**: Only 4 lines added across 2 files
- **Clean architecture**: Uses optional property with fallback logic  
- **Zero breaking changes**: Fully backward compatible
- **Performance impact**: None - same logic, just different values

This fix addresses both suggested solutions from the issue while maintaining all the benefits of our recent discovery system improvements.

Closes #24

## Test plan
- [x] Verify stars brake at reasonable distances (~180-240px)
- [x] Confirm extended star discovery still works (~480-540px)
- [x] Test planets still brake correctly (~68-90px)
- [x] Test moons still brake correctly (~67-70px)
- [x] Verify smooth transit between star systems

🤖 Generated with [Claude Code](https://claude.ai/code)