### PR TITLE
Fix planet and moon discovery ID collision (Issue #30)

### DIFF
--- a/js/celestial/celestial.js
+++ b/js/celestial/celestial.js
@@ -71,13 +71,18 @@ class Planet extends CelestialObject {
     }
 
     // Initialize planet with seeded random for deterministic generation
-    initWithSeed(rng, parentStar = null, orbitalDistance = 0, orbitalAngle = 0, orbitalSpeed = 0, planetType = null) {
+    initWithSeed(rng, parentStar = null, orbitalDistance = 0, orbitalAngle = 0, orbitalSpeed = 0, planetType = null, planetIndex = null) {
         // Update orbital properties if provided
         if (parentStar) {
             this.parentStar = parentStar;
             this.orbitalDistance = orbitalDistance;
             this.orbitalAngle = orbitalAngle;
             this.orbitalSpeed = orbitalSpeed;
+        }
+        
+        // Store planet index for unique ID generation
+        if (planetIndex !== null) {
+            this.planetIndex = planetIndex;
         }
         
         // Update planet type if provided
@@ -116,11 +121,10 @@ class Planet extends CelestialObject {
 
     generateUniqueId() {
         // Use the same logic as the world manager's getObjectId for consistency
-        if (this.parentStar) {
+        if (this.parentStar && this.planetIndex !== undefined) {
             const starX = Math.floor(this.parentStar.x);
             const starY = Math.floor(this.parentStar.y);
-            const orbitalDistance = Math.floor(this.orbitalDistance);
-            return `planet_${starX}_${starY}_orbit_${orbitalDistance}`;
+            return `planet_${starX}_${starY}_planet_${this.planetIndex}`;
         }
         // Fallback for planets without parent stars
         return `planet_${Math.floor(this.x)}_${Math.floor(this.y)}`;
@@ -760,13 +764,18 @@ class Moon extends CelestialObject {
     }
 
     // Initialize moon with seeded random for deterministic generation
-    initWithSeed(rng, parentPlanet = null, orbitalDistance = 0, orbitalAngle = 0, orbitalSpeed = 0) {
+    initWithSeed(rng, parentPlanet = null, orbitalDistance = 0, orbitalAngle = 0, orbitalSpeed = 0, moonIndex = null) {
         // Update orbital properties if provided
         if (parentPlanet) {
             this.parentPlanet = parentPlanet;
             this.orbitalDistance = orbitalDistance;
             this.orbitalAngle = orbitalAngle;
             this.orbitalSpeed = orbitalSpeed;
+        }
+        
+        // Store moon index for unique ID generation
+        if (moonIndex !== null) {
+            this.moonIndex = moonIndex;
         }
         
         // Generate unique identifier for this moon
@@ -786,12 +795,11 @@ class Moon extends CelestialObject {
     }
 
     generateUniqueId() {
-        // Use parent planet's position and orbital distance for stable ID
-        if (this.parentPlanet) {
+        // Use parent planet's position and moon index for stable unique ID
+        if (this.parentPlanet && this.moonIndex !== undefined) {
             const planetX = Math.floor(this.parentPlanet.x);
             const planetY = Math.floor(this.parentPlanet.y);
-            const orbitalDistance = Math.floor(this.orbitalDistance);
-            return `moon_${planetX}_${planetY}_orbit_${orbitalDistance}`;
+            return `moon_${planetX}_${planetY}_moon_${this.moonIndex}`;
         }
         // Fallback for moons without parent planets
         return `moon_${Math.floor(this.x)}_${Math.floor(this.y)}`;

--- a/js/world/world.js
+++ b/js/world/world.js
@@ -19,12 +19,18 @@ class ChunkManager {
     }
 
     getObjectId(x, y, type, object = null) {
-        // For orbiting planets, use parent star position plus orbital distance for stable ID
-        if (object && object.type === 'planet' && object.parentStar) {
+        // For orbiting planets, use parent star position plus planet index for stable unique ID
+        if (object && object.type === 'planet' && object.parentStar && object.planetIndex !== undefined) {
             const starX = Math.floor(object.parentStar.x);
             const starY = Math.floor(object.parentStar.y);
-            const orbitalDistance = Math.floor(object.orbitalDistance);
-            return `${type}_${starX}_${starY}_orbit_${orbitalDistance}`;
+            return `${type}_${starX}_${starY}_planet_${object.planetIndex}`;
+        }
+        
+        // For orbiting moons, use parent planet position plus moon index for stable unique ID
+        if (object && object.type === 'moon' && object.parentPlanet && object.moonIndex !== undefined) {
+            const planetX = Math.floor(object.parentPlanet.x);
+            const planetY = Math.floor(object.parentPlanet.y);
+            return `${type}_${planetX}_${planetY}_moon_${object.moonIndex}`;
         }
         
         // For regular objects, use their position
@@ -213,7 +219,7 @@ class ChunkManager {
                 
                 // Create the planet with orbital properties and type
                 const planet = new Planet(planetX, planetY, star, orbitalDistance, orbitalAngle, orbitalSpeed, planetType);
-                planet.initWithSeed(starSystemRng, star, orbitalDistance, orbitalAngle, orbitalSpeed, planetType);
+                planet.initWithSeed(starSystemRng, star, orbitalDistance, orbitalAngle, orbitalSpeed, planetType, j);
                 
                 // Add planet to both the star's planet list and the chunk
                 star.addPlanet(planet);
@@ -688,7 +694,7 @@ class ChunkManager {
             
             // Create the moon
             const moon = new Moon(moonX, moonY, planet, orbitalDistance, orbitalAngle, orbitalSpeed);
-            moon.initWithSeed(rng, planet, orbitalDistance, orbitalAngle, orbitalSpeed);
+            moon.initWithSeed(rng, planet, orbitalDistance, orbitalAngle, orbitalSpeed, i);
             
             // Add moon to the chunk
             chunk.moons.push(moon);


### PR DESCRIPTION
## Summary
Fixes issue #30 where multiple planets/moons would visually appear as discovered when only one was actually found.

## Root Cause Analysis
The bug was caused by ID collision in orbital object identification:
- Planet/moon IDs used `Math.floor(orbitalDistance)` as part of unique identifier
- Objects with similar orbital distances (e.g., 150.3 and 150.7) both generated ID with "150"
- When one object was discovered, the shared ID got marked as discovered
- `restoreDiscoveryState()` then marked ALL objects with that ID as visually discovered
- Discovery logs showed only one discovery (correct) but multiple objects showed green rings (bug)

## Solution
Replace orbital distance with deterministic index-based unique IDs:

### Planets
- **Before**: `planet_starX_starY_orbit_150` (collision prone)
- **After**: `planet_starX_starY_planet_0` (collision free)

### Moons  
- **Before**: `moon_planetX_planetY_orbit_45` (collision prone)
- **After**: `moon_planetX_planetY_moon_0` (collision free)

## Technical Implementation
- Added `planetIndex` parameter to planet generation (uses loop index `j`)
- Added `moonIndex` parameter to moon generation (uses loop index `i`)  
- Updated `getObjectId()` in world.js to use indices instead of orbital distances
- Updated `generateUniqueId()` methods in Planet and Moon classes
- Maintains deterministic generation for consistent universe across sessions

## Test plan
- [x] Verify planets in same system now have unique IDs even with similar orbital distances
- [x] Verify moons around same planet now have unique IDs even with similar orbital distances  
- [x] Confirm discovery system only marks intended object as discovered
- [x] Ensure deterministic generation still works (same seed = same universe)
- [x] Validate no regression in existing discovery mechanics

## Future Benefits
- Enables potential "discover all planets in system" achievement tracking
- Cleaner foundation for system-level discovery mechanics
- More robust object identification for save/load systems

Closes #30

🤖 Generated with [Claude Code](https://claude.ai/code)