### PR TITLE
Fix mobile logbook close functionality

### DIFF
--- a/js/ui/touchui.js
+++ b/js/ui/touchui.js
@@ -101,9 +101,9 @@ class TouchUI {
                 button.visible = !stellarMap.isVisible();
                 button.targetAlpha = button.visible ? 1 : 0;
             } else if (button.id === 'logbookToggle') {
-                // Show logbook button only when logbook is closed
-                button.visible = !discoveryLogbook.isVisible();
-                button.targetAlpha = button.visible ? 1 : 0;
+                // Always show logbook button - it toggles open/closed
+                button.visible = true;
+                button.targetAlpha = 1;
             } else if (button.id === 'followShip') {
                 // Show follow ship button only when map is open and not following player
                 button.visible = stellarMap.isVisible() && !stellarMap.isFollowingPlayer();


### PR DESCRIPTION
## Summary
Fixes issue #41 where the logbook button on mobile would open the logbook but disappear, leaving no way to close it.

## Changes
- Modified TouchUI logbook button to always be visible instead of hiding when logbook is open
- This allows the button to function as a proper toggle (open/close)
- Matches user expectations and provides consistent mobile UX

## Test Plan
- [x] Logbook button remains visible when logbook is open
- [x] Tapping button when logbook is closed opens it
- [x] Tapping button when logbook is open closes it
- [x] Button behavior is consistent with toggle expectations

Simple one-line fix that resolves the mobile UX issue completely.

Fixes #41

🤖 Generated with [Claude Code](https://claude.ai/code)