### PR TITLE
Fix logbook 100-item display limit

### DIFF
--- a/src/ui/discoverylogbook.ts
+++ b/src/ui/discoverylogbook.ts
@@ -86,11 +86,6 @@ export class DiscoveryLogbook {
         
         this.discoveries.push(discovery);
         
-        // Limit total discoveries to prevent memory issues (keep last 100)
-        if (this.discoveries.length > 100) {
-            this.discoveries = this.discoveries.slice(-100); // Keep the most recent 100
-        }
-        
         // Auto-scroll to bottom when new discovery is added
         this.scrollToBottom();
     }

--- a/tests/ui/discoverylogbook.test.js
+++ b/tests/ui/discoverylogbook.test.js
@@ -151,16 +151,16 @@ describe('DiscoveryLogbook - Discovery History and UI System', () => {
       expect(logbook.discoveries[0].timestamp).toBeLessThanOrEqual(endTime);
     });
 
-    it('should limit discoveries to 100 entries', () => {
+    it('should store all discoveries without limit', () => {
       // Add 105 discoveries
       for (let i = 0; i < 105; i++) {
         logbook.addDiscovery(`Star ${i}`, 'G-type Star', Date.now() + i);
       }
       
-      expect(logbook.discoveries).toHaveLength(100);
-      // Should keep the most recent 100 (Star 5 through Star 104)
-      expect(logbook.discoveries[0].name).toBe('Star 5');
-      expect(logbook.discoveries[99].name).toBe('Star 104');
+      expect(logbook.discoveries).toHaveLength(105);
+      // Should keep all discoveries
+      expect(logbook.discoveries[0].name).toBe('Star 0');
+      expect(logbook.discoveries[104].name).toBe('Star 104');
     });
 
     it('should auto-scroll to bottom when adding discoveries', () => {


### PR DESCRIPTION
## Summary
- Removes the arbitrary 100-item limit in the discovery logbook
- Players can now view all discoveries from their exploration session
- Updates test to verify unlimited storage capability

## Test plan
- [x] Run build and test suite - all tests pass
- [x] Verify logbook can store more than 100 items  
- [x] Update test expectations for unlimited storage

Fixes #55

🤖 Generated with [Claude Code](https://claude.ai/code)