### PR TITLE
Fix speed and distance values to show comma separators (Issue #64)

### DIFF
--- a/src/camera/camera.ts
+++ b/src/camera/camera.ts
@@ -231,11 +231,11 @@ export class Camera {
         const au = kilometers / 149597870.7;
         
         if (au < 0.5) {
-            return `${kilometers.toFixed(1)} km`;
+            return `${kilometers.toLocaleString('en-US', {minimumFractionDigits: 1, maximumFractionDigits: 1})} km`;
         } else if (au < 1000) {
-            return `${au.toFixed(2)} AU`;
+            return `${au.toLocaleString('en-US', {minimumFractionDigits: 2, maximumFractionDigits: 2})} AU`;
         } else {
-            return `${(au / 1000).toFixed(1)} kAU`;
+            return `${(au / 1000).toLocaleString('en-US', {minimumFractionDigits: 1, maximumFractionDigits: 1})} kAU`;
         }
     }
 
@@ -247,13 +247,13 @@ export class Camera {
         const au = kilometers / 149597870.7;
         
         if (au < 0.5) {
-            return `${kilometers.toFixed(1)} km`;
+            return `${kilometers.toLocaleString('en-US', {minimumFractionDigits: 1, maximumFractionDigits: 1})} km`;
         } else if (au < 1000) {
-            return `${au.toFixed(2)} AU`;
+            return `${au.toLocaleString('en-US', {minimumFractionDigits: 2, maximumFractionDigits: 2})} AU`;
         } else if (au < 1000000) {
-            return `${(au / 1000).toFixed(1)} kAU`;
+            return `${(au / 1000).toLocaleString('en-US', {minimumFractionDigits: 1, maximumFractionDigits: 1})} kAU`;
         } else {
-            return `${(au / 1000000).toFixed(2)} MAU`;
+            return `${(au / 1000000).toLocaleString('en-US', {minimumFractionDigits: 2, maximumFractionDigits: 2})} MAU`;
         }
     }
 
@@ -272,20 +272,20 @@ export class Camera {
             // Show in km/h for very slow speeds
             const kmPerHour = kmPerSecond * 3600;
             if (kmPerHour < 1) {
-                return `${Math.round(kmPerHour * 10) / 10} km/h`;
+                return `${(Math.round(kmPerHour * 10) / 10).toLocaleString('en-US', {minimumFractionDigits: 1, maximumFractionDigits: 1})} km/h`;
             } else {
-                return `${Math.round(kmPerHour).toLocaleString()} km/h`;
+                return `${Math.round(kmPerHour).toLocaleString('en-US')} km/h`;
             }
         } else if (kmPerSecond < 100000) {
             // Show in km/s for moderate to high speeds
-            return `${Math.round(kmPerSecond * 10) / 10} km/s`;
+            return `${(Math.round(kmPerSecond * 10) / 10).toLocaleString('en-US', {minimumFractionDigits: 1, maximumFractionDigits: 1})} km/s`;
         } else {
             // For very high speeds, show in AU/s
             const auPerSecond = kmPerSecond / 149597870.7;
             if (auPerSecond < 1) {
-                return `${Math.round(auPerSecond * 1000000) / 1000000} AU/s`;
+                return `${(Math.round(auPerSecond * 1000000) / 1000000).toLocaleString('en-US', {minimumFractionDigits: 6, maximumFractionDigits: 6})} AU/s`;
             } else {
-                return `${Math.round(auPerSecond * 100) / 100} AU/s`;
+                return `${(Math.round(auPerSecond * 100) / 100).toLocaleString('en-US', {minimumFractionDigits: 2, maximumFractionDigits: 2})} AU/s`;
             }
         }
     }

--- a/tests/camera/camera.test.js
+++ b/tests/camera/camera.test.js
@@ -408,11 +408,11 @@ describe('Camera Physics and Movement', () => {
     it('should format distance correctly', () => {
       // Test kilometers (current system uses km not m)
       camera.sessionDistanceTraveled = 5000; // 5000 pixels = 50000 km (with 10000 scale)
-      expect(camera.getFormattedDistance()).toMatch(/50000\.0 km/);
+      expect(camera.getFormattedDistance()).toMatch(/50,000\.0 km/);
       
       // Test kilometers
       camera.sessionDistanceTraveled = 50000; // 50000 pixels = 500000 km (with 10000 scale)
-      expect(camera.getFormattedDistance()).toMatch(/500000\.0 km/);
+      expect(camera.getFormattedDistance()).toMatch(/500,000\.0 km/);
       
       // Test AU (current system uses AU not Mm)
       camera.sessionDistanceTraveled = 15000000; // Large distance converts to AU


### PR DESCRIPTION
- Updated getFormattedDistance() to use toLocaleString() with proper decimal formatting
- Updated getFormattedLifetimeDistance() to use toLocaleString() with proper decimal formatting
- Updated getFormattedSpeed() to use toLocaleString() consistently across all units
- Numbers now display with comma separators (e.g., 1,234.5 km instead of 1234.5 km)
- Maintains proper decimal place formatting for different units (km, AU, kAU, MAU)