### PR TITLE
Fix stellar map discovery persistence and asteroid garden integration

### DIFF
--- a/src/game.ts
+++ b/src/game.ts
@@ -263,7 +263,8 @@ export class Game {
                 const discoveredStars = this.chunkManager.getDiscoveredStars();
                 const discoveredPlanets = this.chunkManager.getDiscoveredPlanets();
                 const discoveredNebulae = this.chunkManager.getDiscoveredNebulae();
-                this.stellarMap.handleStarSelection(this.input.getMouseX(), this.input.getMouseY(), discoveredStars, this.renderer.canvas, discoveredPlanets, discoveredNebulae);
+                const discoveredAsteroidGardens = this.chunkManager.getDiscoveredAsteroidGardens();
+                this.stellarMap.handleStarSelection(this.input.getMouseX(), this.input.getMouseY(), discoveredStars, this.renderer.canvas, discoveredPlanets, discoveredNebulae, discoveredAsteroidGardens);
             }
         }
         
@@ -278,7 +279,8 @@ export class Game {
             const discoveredStars = this.chunkManager.getDiscoveredStars();
             const discoveredPlanets = this.chunkManager.getDiscoveredPlanets();
             const discoveredNebulae = this.chunkManager.getDiscoveredNebulae();
-            this.stellarMap.detectHoverTarget(this.input.getMouseX(), this.input.getMouseY(), this.renderer.canvas, discoveredStars, discoveredPlanets, discoveredNebulae);
+            const discoveredAsteroidGardens = this.chunkManager.getDiscoveredAsteroidGardens();
+            this.stellarMap.detectHoverTarget(this.input.getMouseX(), this.input.getMouseY(), this.renderer.canvas, discoveredStars, discoveredPlanets, discoveredNebulae, discoveredAsteroidGardens);
         } else {
             // Reset cursor when map is not visible
             this.stellarMap.updateCursor(this.renderer.canvas);
@@ -796,7 +798,8 @@ export class Game {
         const discoveredPlanets = this.chunkManager.getDiscoveredPlanets();
         const discoveredNebulae = this.chunkManager.getDiscoveredNebulae();
         const discoveredWormholes = this.chunkManager.getDiscoveredWormholes();
-        this.stellarMap.render(this.renderer, this.camera, discoveredStars, this.gameStartingPosition, discoveredPlanets, discoveredNebulae, discoveredWormholes);
+        const discoveredAsteroidGardens = this.chunkManager.getDiscoveredAsteroidGardens();
+        this.stellarMap.render(this.renderer, this.camera, discoveredStars, this.gameStartingPosition, discoveredPlanets, discoveredNebulae, discoveredWormholes, discoveredAsteroidGardens);
         
         // Render touch UI (renders on top of everything else)
         this.touchUI.render(this.renderer);

--- a/src/ui/stellarmap.ts
+++ b/src/ui/stellarmap.ts
@@ -56,6 +56,19 @@ interface WormholeLike {
     timestamp?: number;
 }
 
+interface AsteroidGardenLike {
+    x: number;
+    y: number;
+    gardenType: string;
+    gardenTypeData?: {
+        name: string;
+        colors?: string[];
+        accentColors?: string[];
+    };
+    objectName?: string;
+    timestamp?: number;
+}
+
 interface NamingService {
     generateDisplayName(object: any): string;
     generateFullDesignation(object: any): {
@@ -85,6 +98,8 @@ export class StellarMap {
     hoveredNebula: NebulaLike | null;
     selectedWormhole: WormholeLike | null;
     hoveredWormhole: WormholeLike | null;
+    selectedAsteroidGarden: AsteroidGardenLike | null;
+    hoveredAsteroidGarden: AsteroidGardenLike | null;
     namingService: NamingService | null;
     
     // Interactive panning state
@@ -117,6 +132,8 @@ export class StellarMap {
         this.hoveredNebula = null;
         this.selectedWormhole = null;
         this.hoveredWormhole = null;
+        this.selectedAsteroidGarden = null;
+        this.hoveredAsteroidGarden = null;
         this.namingService = null; // Will be injected
         
         // Interactive panning state
@@ -266,7 +283,7 @@ export class StellarMap {
         this.panStartY = 0;
     }
     
-    handleStarSelection(mouseX: number, mouseY: number, discoveredStars: StarLike[], canvas: HTMLCanvasElement, discoveredPlanets?: PlanetLike[] | null, discoveredNebulae?: NebulaLike[] | null): boolean {
+    handleStarSelection(mouseX: number, mouseY: number, discoveredStars: StarLike[], canvas: HTMLCanvasElement, discoveredPlanets?: PlanetLike[] | null, discoveredNebulae?: NebulaLike[] | null, discoveredAsteroidGardens?: AsteroidGardenLike[] | null): boolean {
         if (!discoveredStars) return false;
         
         // Calculate map bounds
@@ -278,6 +295,7 @@ export class StellarMap {
             this.selectedStar = null;
             this.selectedPlanet = null;
             this.selectedNebula = null;
+            this.selectedAsteroidGarden = null;
             return false;
         }
         
@@ -285,9 +303,11 @@ export class StellarMap {
         let closestStar: StarLike | null = null;
         let closestPlanet: PlanetLike | null = null;
         let closestNebula: NebulaLike | null = null;
+        let closestAsteroidGarden: AsteroidGardenLike | null = null;
         let closestStarDistance = Infinity;
         let closestPlanetDistance = Infinity;
         let closestNebulaDistance = Infinity;
+        let closestAsteroidGardenDistance = Infinity;
         const clickThreshold = 10; // pixels
         
         // Check for planet clicks first (in detail view)
@@ -353,23 +373,52 @@ export class StellarMap {
             }
         }
         
-        // Select the closest object (prioritize order: planets > nebulae > stars)
-        if (closestPlanet && closestPlanetDistance <= Math.min(closestStarDistance, closestNebulaDistance)) {
+        // Check for asteroid garden clicks
+        if (discoveredAsteroidGardens) {
+            for (const asteroidGarden of discoveredAsteroidGardens) {
+                const gardenMapX = mapX + mapWidth/2 + (asteroidGarden.x - this.centerX) * worldToMapScale;
+                const gardenMapY = mapY + mapHeight/2 + (asteroidGarden.y - this.centerY) * worldToMapScale;
+                
+                // Use larger click threshold for asteroid gardens since they're spread out
+                const gardenClickThreshold = Math.max(20, clickThreshold);
+                if (gardenMapX >= mapX && gardenMapX <= mapX + mapWidth && 
+                    gardenMapY >= mapY && gardenMapY <= mapY + mapHeight) {
+                    
+                    const distance = Math.sqrt((mouseX - gardenMapX)**2 + (mouseY - gardenMapY)**2);
+                    if (distance <= gardenClickThreshold && distance < closestAsteroidGardenDistance) {
+                        closestAsteroidGarden = asteroidGarden;
+                        closestAsteroidGardenDistance = distance;
+                    }
+                }
+            }
+        }
+        
+        // Select the closest object (prioritize order: planets > nebulae > asteroid gardens > stars)
+        if (closestPlanet && closestPlanetDistance <= Math.min(closestStarDistance, closestNebulaDistance, closestAsteroidGardenDistance)) {
             this.selectedPlanet = closestPlanet;
             this.selectedStar = null;
             this.selectedNebula = null;
-        } else if (closestNebula && closestNebulaDistance <= closestStarDistance) {
+            this.selectedAsteroidGarden = null;
+        } else if (closestNebula && closestNebulaDistance <= Math.min(closestStarDistance, closestAsteroidGardenDistance)) {
             this.selectedNebula = closestNebula;
             this.selectedStar = null;
             this.selectedPlanet = null;
+            this.selectedAsteroidGarden = null;
+        } else if (closestAsteroidGarden && closestAsteroidGardenDistance <= closestStarDistance) {
+            this.selectedAsteroidGarden = closestAsteroidGarden;
+            this.selectedStar = null;
+            this.selectedPlanet = null;
+            this.selectedNebula = null;
         } else if (closestStar) {
             this.selectedStar = closestStar;
             this.selectedPlanet = null;
             this.selectedNebula = null;
+            this.selectedAsteroidGarden = null;
         } else {
             this.selectedStar = null;
             this.selectedPlanet = null;
             this.selectedNebula = null;
+            this.selectedAsteroidGarden = null;
         }
         
         return true; // Consumed the event
@@ -391,7 +440,7 @@ export class StellarMap {
         this.updateCursor(canvas);
     }
     
-    detectHoverTarget(mouseX: number, mouseY: number, canvas: HTMLCanvasElement, discoveredStars: StarLike[], discoveredPlanets?: PlanetLike[] | null, discoveredNebulae?: NebulaLike[] | null): void {
+    detectHoverTarget(mouseX: number, mouseY: number, canvas: HTMLCanvasElement, discoveredStars: StarLike[], discoveredPlanets?: PlanetLike[] | null, discoveredNebulae?: NebulaLike[] | null, discoveredAsteroidGardens?: AsteroidGardenLike[] | null): void {
         if (!this.visible) return;
         
         // Calculate map bounds and scaling
@@ -403,6 +452,8 @@ export class StellarMap {
             this.hoveredStar = null;
             this.hoveredPlanet = null;
             this.hoveredNebula = null;
+            this.hoveredWormhole = null;
+            this.hoveredAsteroidGarden = null;
             this.updateCursor(canvas);
             return;
         }
@@ -411,9 +462,11 @@ export class StellarMap {
         let closestStar: StarLike | null = null;
         let closestPlanet: PlanetLike | null = null;
         let closestNebula: NebulaLike | null = null;
+        let closestAsteroidGarden: AsteroidGardenLike | null = null;
         let closestStarDistance = Infinity;
         let closestPlanetDistance = Infinity;
         let closestNebulaDistance = Infinity;
+        let closestAsteroidGardenDistance = Infinity;
         const hoverThreshold = 15; // Slightly larger than click threshold for better UX
         
         // Check for planet hover first (in detail view)
@@ -479,23 +532,52 @@ export class StellarMap {
             }
         }
         
-        // Set hover state (prioritize order: planets > nebulae > stars)
-        if (closestPlanet && closestPlanetDistance <= Math.min(closestStarDistance, closestNebulaDistance)) {
+        // Check for asteroid garden hover
+        if (discoveredAsteroidGardens) {
+            for (const asteroidGarden of discoveredAsteroidGardens) {
+                const gardenMapX = mapX + mapWidth/2 + (asteroidGarden.x - this.centerX) * worldToMapScale;
+                const gardenMapY = mapY + mapHeight/2 + (asteroidGarden.y - this.centerY) * worldToMapScale;
+                
+                // Use larger hover threshold for asteroid gardens since they're spread out
+                const gardenHoverThreshold = Math.max(25, hoverThreshold);
+                if (gardenMapX >= mapX && gardenMapX <= mapX + mapWidth && 
+                    gardenMapY >= mapY && gardenMapY <= mapY + mapHeight) {
+                    
+                    const distance = Math.sqrt((mouseX - gardenMapX)**2 + (mouseY - gardenMapY)**2);
+                    if (distance <= gardenHoverThreshold && distance < closestAsteroidGardenDistance) {
+                        closestAsteroidGarden = asteroidGarden;
+                        closestAsteroidGardenDistance = distance;
+                    }
+                }
+            }
+        }
+        
+        // Set hover state (prioritize order: planets > nebulae > asteroid gardens > stars)
+        if (closestPlanet && closestPlanetDistance <= Math.min(closestStarDistance, closestNebulaDistance, closestAsteroidGardenDistance)) {
             this.hoveredPlanet = closestPlanet;
             this.hoveredStar = null;
             this.hoveredNebula = null;
-        } else if (closestNebula && closestNebulaDistance <= closestStarDistance) {
+            this.hoveredAsteroidGarden = null;
+        } else if (closestNebula && closestNebulaDistance <= Math.min(closestStarDistance, closestAsteroidGardenDistance)) {
             this.hoveredNebula = closestNebula;
             this.hoveredStar = null;
             this.hoveredPlanet = null;
+            this.hoveredAsteroidGarden = null;
+        } else if (closestAsteroidGarden && closestAsteroidGardenDistance <= closestStarDistance) {
+            this.hoveredAsteroidGarden = closestAsteroidGarden;
+            this.hoveredStar = null;
+            this.hoveredPlanet = null;
+            this.hoveredNebula = null;
         } else if (closestStar) {
             this.hoveredStar = closestStar;
             this.hoveredPlanet = null;
             this.hoveredNebula = null;
+            this.hoveredAsteroidGarden = null;
         } else {
             this.hoveredStar = null;
             this.hoveredPlanet = null;
             this.hoveredNebula = null;
+            this.hoveredAsteroidGarden = null;
         }
         
         // Update cursor based on hover state
@@ -503,7 +585,7 @@ export class StellarMap {
     }
     
     updateCursor(canvas: HTMLCanvasElement): void {
-        if (this.hoveredStar || this.hoveredPlanet || this.hoveredNebula || this.hoveredWormhole) {
+        if (this.hoveredStar || this.hoveredPlanet || this.hoveredNebula || this.hoveredWormhole || this.hoveredAsteroidGarden) {
             canvas.style.cursor = 'pointer';
         } else if (this.visible) {
             // Use crosshair for map navigation when visible
@@ -563,7 +645,7 @@ export class StellarMap {
         this.zoomLevel = Math.max(this.zoomLevel / 1.5, 0.01);
     }
 
-    render(renderer: Renderer, camera: Camera, discoveredStars: StarLike[], gameStartingPosition?: GameStartingPosition | null, discoveredPlanets?: PlanetLike[] | null, discoveredNebulae?: NebulaLike[] | null, discoveredWormholes?: WormholeLike[] | null): void {
+    render(renderer: Renderer, camera: Camera, discoveredStars: StarLike[], gameStartingPosition?: GameStartingPosition | null, discoveredPlanets?: PlanetLike[] | null, discoveredNebulae?: NebulaLike[] | null, discoveredWormholes?: WormholeLike[] | null, discoveredAsteroidGardens?: AsteroidGardenLike[] | null): void {
         if (!this.visible) return;
 
         const { canvas, ctx } = renderer;
@@ -612,20 +694,19 @@ export class StellarMap {
             this.renderDiscoveredPlanets(ctx, mapX, mapY, mapWidth, mapHeight, worldToMapScale, discoveredPlanets);
         }
 
-        // Draw discovered nebulae (larger scale objects, visible at all zoom levels for debugging)
+        // Draw discovered nebulae (larger scale objects, visible at all zoom levels)
         if (discoveredNebulae && discoveredNebulae.length > 0) {
-            console.log(`[StellarMap] Rendering ${discoveredNebulae.length} nebulae on map`);
             this.renderDiscoveredNebulae(ctx, mapX, mapY, mapWidth, mapHeight, worldToMapScale, discoveredNebulae);
-        } else {
-            console.log(`[StellarMap] No nebulae to render: ${discoveredNebulae ? discoveredNebulae.length : 'null'}`);
         }
 
         // Draw discovered wormholes (ultra-rare spacetime anomalies with pair connections)
         if (discoveredWormholes && discoveredWormholes.length > 0) {
-            console.log(`[StellarMap] Rendering ${discoveredWormholes.length} wormholes on map`);
             this.renderDiscoveredWormholes(ctx, mapX, mapY, mapWidth, mapHeight, worldToMapScale, discoveredWormholes);
-        } else {
-            console.log(`[StellarMap] No wormholes to render: ${discoveredWormholes ? discoveredWormholes.length : 'null'}`);
+        }
+
+        // Draw discovered asteroid gardens (scattered rock fields, visible at most zoom levels)
+        if (discoveredAsteroidGardens && discoveredAsteroidGardens.length > 0) {
+            this.renderDiscoveredAsteroidGardens(ctx, mapX, mapY, mapWidth, mapHeight, worldToMapScale, discoveredAsteroidGardens);
         }
         
         // Draw origin (0,0) marker
@@ -1269,6 +1350,161 @@ export class StellarMap {
         ctx.setLineDash([]);
     }
 
+    renderDiscoveredAsteroidGardens(ctx: CanvasRenderingContext2D, mapX: number, mapY: number, mapWidth: number, mapHeight: number, scale: number, discoveredAsteroidGardens: AsteroidGardenLike[]): void {
+        if (!discoveredAsteroidGardens) return;
+
+        for (const asteroidGarden of discoveredAsteroidGardens) {
+            // Convert world coordinates to map coordinates
+            const gardenMapX = mapX + mapWidth/2 + (asteroidGarden.x - this.centerX) * scale;
+            const gardenMapY = mapY + mapHeight/2 + (asteroidGarden.y - this.centerY) * scale;
+            
+            // Calculate asteroid garden size (smaller than nebulae, larger than planets)
+            const baseSize = 4; // Smaller than nebulae (8), larger than planets (1.5-2.6)
+            const gardenSize = Math.max(2, baseSize * Math.min(1.0, this.zoomLevel * 0.8));
+            
+            // Check if asteroid garden is within map bounds (with margin for size)
+            const margin = gardenSize + 5;
+            if (gardenMapX >= mapX - margin && gardenMapX <= mapX + mapWidth + margin && 
+                gardenMapY >= mapY - margin && gardenMapY <= mapY + mapHeight + margin) {
+                
+                // Get asteroid garden colors
+                const gardenColors = this.getAsteroidGardenColors(asteroidGarden);
+                
+                ctx.save();
+                
+                // Draw asteroid garden as scattered dots with glitter effect
+                this.renderAsteroidField(ctx, gardenMapX, gardenMapY, gardenSize, gardenColors, asteroidGarden.x, asteroidGarden.y);
+                
+                // Add selection highlight if this asteroid garden is selected
+                if (this.selectedAsteroidGarden === asteroidGarden) {
+                    ctx.strokeStyle = this.currentPositionColor;
+                    ctx.lineWidth = 2;
+                    ctx.beginPath();
+                    const highlightRadius = gardenSize + 2;
+                    ctx.arc(gardenMapX, gardenMapY, highlightRadius, 0, Math.PI * 2);
+                    ctx.stroke();
+                }
+                
+                // Add hover highlight if this asteroid garden is hovered
+                if (this.hoveredAsteroidGarden === asteroidGarden) {
+                    ctx.strokeStyle = this.currentPositionColor + '80'; // Semi-transparent
+                    ctx.lineWidth = 1;
+                    ctx.beginPath();
+                    const hoverRadius = gardenSize + 1;
+                    ctx.arc(gardenMapX, gardenMapY, hoverRadius, 0, Math.PI * 2);
+                    ctx.stroke();
+                }
+                
+                ctx.restore();
+                
+                // Render asteroid garden label if zoomed in enough or selected
+                if (this.zoomLevel > 2.0 || this.selectedAsteroidGarden === asteroidGarden) {
+                    this.renderAsteroidGardenLabel(ctx, asteroidGarden, gardenMapX, gardenMapY);
+                }
+            }
+        }
+    }
+
+    renderAsteroidField(ctx: CanvasRenderingContext2D, centerX: number, centerY: number, size: number, colors: {rocks: string[], accents: string[]}, worldX: number, worldY: number): void {
+        // Draw several small rocks scattered around the center point
+        const rockCount = Math.max(4, Math.floor(size * 0.8)); // More rocks, better distribution
+        const spreadRadius = size * 2.5; // Much wider spread
+        
+        // Use deterministic "randomness" based on WORLD position for consistent appearance across all map movements
+        const seed = Math.floor(worldX + worldY * 1000);
+        
+        for (let i = 0; i < rockCount; i++) {
+            // Create more spread out, less uniform distribution
+            const pseudoRandom1 = Math.sin(seed + i * 1.618) * 0.5 + 0.5; // Golden ratio for better distribution
+            const pseudoRandom2 = Math.sin(seed + i * 2.414) * 0.5 + 0.5; // Different multiplier for Y
+            const pseudoRandom3 = Math.sin(seed + i * 3.142) * 0.5 + 0.5; // For size variation
+            
+            // Distribute rocks with more variation and spread
+            const angle = (i / rockCount) * Math.PI * 2 + (pseudoRandom1 - 0.5) * Math.PI * 0.8; // More angular variation
+            const distance = pseudoRandom2 * spreadRadius * (0.3 + pseudoRandom1 * 0.7); // Variable distance, some closer to center
+            const rockX = centerX + Math.cos(angle) * distance;
+            const rockY = centerY + Math.sin(angle) * distance;
+            const rockSize = Math.max(1, size * (0.2 + pseudoRandom3 * 0.5)); // More size variation
+            
+            // Draw rock
+            ctx.fillStyle = colors.rocks[i % colors.rocks.length];
+            ctx.beginPath();
+            ctx.arc(rockX, rockY, rockSize, 0, Math.PI * 2);
+            ctx.fill();
+            
+            // Add occasional glitter effect (reduced frequency and more subtle)
+            const glitterChance = 0.3; // Reduced from 70% to 30%
+            const glitterRandom = Math.sin(seed + i * 5.678) * 0.5 + 0.5;
+            if (glitterRandom < glitterChance) {
+                const glitterX = rockX + (pseudoRandom1 - 0.5) * rockSize * 0.8;
+                const glitterY = rockY + (pseudoRandom2 - 0.5) * rockSize * 0.8;
+                const glitterSize = Math.max(0.3, rockSize * 0.2); // Smaller glitter
+                
+                // Use more subtle glitter colors (blend with rock color)
+                const accentColor = colors.accents[Math.floor(pseudoRandom3 * colors.accents.length)];
+                ctx.fillStyle = accentColor + '80'; // Add transparency for subtlety
+                ctx.beginPath();
+                ctx.arc(glitterX, glitterY, glitterSize, 0, Math.PI * 2);
+                ctx.fill();
+            }
+        }
+    }
+
+    getAsteroidGardenColors(asteroidGarden: AsteroidGardenLike): {rocks: string[], accents: string[]} {
+        // Use colors from the asteroid garden type data if available
+        if (asteroidGarden.gardenTypeData?.colors && asteroidGarden.gardenTypeData?.accentColors) {
+            return {
+                rocks: asteroidGarden.gardenTypeData.colors,
+                accents: asteroidGarden.gardenTypeData.accentColors
+            };
+        }
+        
+        // Fallback colors based on garden type
+        const colorSchemes: Record<string, {rocks: string[], accents: string[]}> = {
+            metallic: {
+                rocks: ['#8c8c8c', '#a0a0a0', '#7a7a7a'],
+                accents: ['#ffffff', '#e6e6e6', '#d4d4d4']
+            },
+            carbonaceous: {
+                rocks: ['#2d2d2d', '#404040', '#1a1a1a'],
+                accents: ['#4a90e2', '#7bb3f0', '#a8c8ec']
+            },
+            crystalline: {
+                rocks: ['#e6f3ff', '#d4e6f1', '#aed6f1'],
+                accents: ['#ffffff', '#85c1e9', '#5dade2']
+            },
+            volcanic: {
+                rocks: ['#8b4513', '#a0522d', '#d2691e'],
+                accents: ['#ff4500', '#ff6347', '#ffa500']
+            }
+        };
+        
+        return colorSchemes[asteroidGarden.gardenType] || colorSchemes.metallic;
+    }
+
+    renderAsteroidGardenLabel(ctx: CanvasRenderingContext2D, asteroidGarden: AsteroidGardenLike, gardenMapX: number, gardenMapY: number): void {
+        if (!this.namingService) return;
+        
+        const gardenName = asteroidGarden.objectName || this.namingService.generateDisplayName(asteroidGarden);
+        
+        ctx.save();
+        ctx.fillStyle = '#e8f4fd';
+        ctx.font = '10px "Courier New", monospace';
+        ctx.textAlign = 'center';
+        
+        // Draw text background for readability
+        const textWidth = ctx.measureText(gardenName).width;
+        const bgPadding = 3;
+        ctx.fillStyle = '#000000B0';
+        ctx.fillRect(gardenMapX - textWidth/2 - bgPadding, gardenMapY + 12, textWidth + bgPadding*2, 12);
+        
+        // Draw label text
+        ctx.fillStyle = '#e8f4fd';
+        ctx.fillText(gardenName, gardenMapX, gardenMapY + 22);
+        
+        ctx.restore();
+    }
+
     calculatePlanetSize(planet: PlanetLike): number {
         // Get the planet's size multiplier from its planet type (default 1.0 if not available)
         const sizeMultiplier = planet.planetType?.sizeMultiplier || 1.0;
@@ -1522,6 +1758,8 @@ export class StellarMap {
             this.renderPlanetInfoPanel(ctx, canvas);
         } else if (this.selectedNebula && this.namingService) {
             this.renderNebulaInfoPanel(ctx, canvas);
+        } else if (this.selectedAsteroidGarden && this.namingService) {
+            this.renderAsteroidGardenInfoPanel(ctx, canvas);
         }
     }
 
@@ -1698,6 +1936,70 @@ export class StellarMap {
         } catch (error) {
             console.warn('Failed to generate nebula name:', error);
             return `Nebula`;
+        }
+    }
+
+    renderAsteroidGardenInfoPanel(ctx: CanvasRenderingContext2D, canvas: HTMLCanvasElement): void {
+        if (!this.selectedAsteroidGarden || !this.namingService) return;
+        
+        // Panel dimensions and position (same as other panels)
+        const panelWidth = 300;
+        const panelHeight = 120;
+        const panelX = canvas.width - panelWidth - 20;
+        const panelY = 60;
+        
+        // Draw panel background (same style as other panels)
+        ctx.fillStyle = '#000000E0';
+        ctx.fillRect(panelX, panelY, panelWidth, panelHeight);
+        ctx.strokeStyle = '#2a3a4a';
+        ctx.lineWidth = 1;
+        ctx.strokeRect(panelX, panelY, panelWidth, panelHeight);
+        
+        // Panel content (same style as other panels)
+        ctx.fillStyle = '#b0c4d4';
+        ctx.font = '12px "Courier New", monospace';
+        
+        let lineY = panelY + 20;
+        const lineHeight = 14;
+        
+        // Asteroid garden designation
+        const gardenName = this.generateAsteroidGardenDisplayName(this.selectedAsteroidGarden);
+        ctx.fillText(`Designation: ${gardenName}`, panelX + 10, lineY);
+        lineY += lineHeight;
+        
+        // Garden type
+        const gardenTypeName = this.selectedAsteroidGarden.gardenTypeData?.name || this.selectedAsteroidGarden.gardenType;
+        ctx.fillText(`Type: ${gardenTypeName}`, panelX + 10, lineY);
+        lineY += lineHeight;
+        
+        // Garden position
+        ctx.fillText(`Position: (${this.selectedAsteroidGarden.x.toFixed(0)}, ${this.selectedAsteroidGarden.y.toFixed(0)})`, panelX + 10, lineY);
+        lineY += lineHeight;
+        
+        // Discovery timestamp if available
+        if (this.selectedAsteroidGarden.timestamp) {
+            const date = new Date(this.selectedAsteroidGarden.timestamp);
+            const dateStr = date.toLocaleDateString();
+            ctx.fillText(`Discovered: ${dateStr}`, panelX + 10, lineY);
+        }
+    }
+
+    generateAsteroidGardenDisplayName(asteroidGarden: AsteroidGardenLike): string {
+        // Use stored asteroid garden name from discovery data if available
+        if (asteroidGarden.objectName) {
+            return asteroidGarden.objectName;
+        }
+
+        // Fallback to naming service if no stored name
+        if (!this.namingService) {
+            return `Asteroid Garden`;
+        }
+
+        // Generate name using naming service
+        try {
+            return this.namingService.generateDisplayName(asteroidGarden);
+        } catch (error) {
+            return `Asteroid Garden`;
         }
     }
 


### PR DESCRIPTION
* Remove noisy debug logging from ChunkManager discovery methods
* Add fallback logic for nebulae/wormholes when chunks are unloaded
* Fix nebula type consistency by using stored discovery data
* Add complete asteroid garden support to stellar map:
  - Hover detection and cursor changes
  - Click selection and info panel display
  - Deterministic glitter rendering using world coordinates
  - Consistent info panel styling with other celestial objects
* Ensure all discovered objects persist on map regardless of chunk status
* Fix chaotic glitter effect caused by map coordinate dependency

All objects now maintain consistent appearance and interactions across chunk loading/unloading cycles for seamless exploration.