### PR TITLE
Fix input state corruption during cosmic transitions (black hole/wormhole)

### DIFF
--- a/src/game.ts
+++ b/src/game.ts
@@ -204,12 +204,16 @@ export class Game {
         // Handle wormhole traversal transition
         if (this.isTraversing) {
             this.updateTraversal(deltaTime);
+            // Still clear frame state to prevent input corruption during traversal
+            this.input.clearFrameState();
             return; // Skip normal updates during traversal
         }
         
         // Handle universe reset transition
         if (this.isResettingUniverse) {
             this.updateUniverseReset(deltaTime);
+            // Still clear frame state to prevent input corruption during cosmic transition
+            this.input.clearFrameState();
             return; // Skip normal updates during cosmic transition
         }
         


### PR DESCRIPTION
## 🌌 Critical Debug Mode Fix

This PR fixes a critical issue where debug hotkey safety was being bypassed after cosmic transitions (black hole encounters and wormhole traversals), allowing unintended debug command triggers.

### Issue Description
**Reported Issue**: After entering a black hole, the W key would spawn wormholes regardless of Shift key state, bypassing the safety system implemented in PR #82.

**Root Cause**: During cosmic transitions, the game loop returns early and skips the `clearFrameState()` call, causing input state corruption that bypasses debug safety checks.

### Technical Analysis
**The Problem Flow:**
1. Player enters black hole → `isResettingUniverse = true`
2. Game loop calls `updateUniverseReset()` then returns early
3. Normal `clearFrameState()` call at end of update is skipped
4. Browser input events continue processing with stale state
5. `shiftPressedFirst` and `keyPressed` become corrupted
6. Debug commands bypass safety checks with corrupted state

**Same issue affects:**
- Black hole universe reset transitions
- Wormhole traversal transitions

### Solution Implemented
**Ensure Frame State Clearing During Transitions:**
- Add `input.clearFrameState()` before early return in universe reset
- Add `input.clearFrameState()` before early return in wormhole traversal
- Maintains proper input state management during all cosmic events

### Code Changes
```typescript
// Universe reset transition
if (this.isResettingUniverse) {
    this.updateUniverseReset(deltaTime);
    // Still clear frame state to prevent input corruption during cosmic transition
    this.input.clearFrameState();
    return; // Skip normal updates during cosmic transition
}

// Wormhole traversal transition  
if (this.isTraversing) {
    this.updateTraversal(deltaTime);
    // Still clear frame state to prevent input corruption during traversal
    this.input.clearFrameState();
    return; // Skip normal updates during traversal
}
```

### Impact
✅ **Fixes W key spawning wormholes after black hole encounters**  
✅ **Prevents debug command bypass during any cosmic transition**  
✅ **Maintains robust debug safety across all game states**  
✅ **No functional changes to cosmic transitions themselves**  
✅ **All 72 tests pass - no regressions**

### Testing
- Verified fix resolves the black hole input corruption issue
- Confirmed wormhole traversal also protected
- All existing tests pass
- Debug safety system maintains integrity during cosmic events

This complements PR #82's debug safety system by ensuring it works correctly during all game states, including cosmic transitions.