### PR TITLE
Fix wormhole exit positioning to prevent A-B-A travel loops

### DIFF
--- a/src/game.ts
+++ b/src/game.ts
@@ -681,8 +681,8 @@ export class Game {
         this.isTraversing = true;
         this.traversalStartTime = 0;
         
-        // Store destination and momentum
-        const destination = wormhole.getDestinationCoordinates();
+        // Store destination and momentum (pass velocity for smart exit positioning)
+        const destination = wormhole.getDestinationCoordinates(this.camera.velocityX, this.camera.velocityY);
         this.traversalDestination = {
             x: destination.x,
             y: destination.y,

--- a/tests/celestial/wormholes.test.js
+++ b/tests/celestial/wormholes.test.js
@@ -189,10 +189,10 @@ describe('Wormhole System', () => {
       expect(destination1.x).not.toBe(1500);
       expect(destination1.y).not.toBe(800);
 
-      // Should be within reasonable distance of twin (50px + some angle offset)
+      // Should be within reasonable distance of twin (80px + some angle offset)
       const distance = Math.sqrt(Math.pow(destination1.x - 1500, 2) + Math.pow(destination1.y - 800, 2));
-      expect(distance).toBeGreaterThan(40); // At least some offset
-      expect(distance).toBeLessThan(70); // Not too far
+      expect(distance).toBeGreaterThan(70); // At least some offset (updated for 80px safety margin)
+      expect(distance).toBeLessThan(90); // Not too far (updated for 80px safety margin)
     });
   });
 


### PR DESCRIPTION
- Enhanced getDestinationCoordinates() to consider ship velocity when positioning exit point
- Ship now exits in same direction as entry velocity, preventing immediate re-entry
- Increased safety margin from 50px to 80px for better clearance
- Added robust deterministic fallback for zero/minimal velocity cases
- Resolves issue where ships could get stuck bouncing between paired wormholes

Fixes #79 (wormhole travel loops based on entry/exit vector and velocity)