### PR TITLE
fix(stellar-map): register beta wormholes in discovery database

### DIFF
--- a/src/services/StateManager.ts
+++ b/src/services/StateManager.ts
@@ -257,6 +257,10 @@ export class StateManager {
         if (sourceWormhole.discovered) {
             betaWormhole.discovered = true;
             betaWormhole.discoveryTimestamp = sourceWormhole.discoveryTimestamp;
+            
+            // CRITICAL FIX: Add beta wormhole to discovery database so it appears on stellar map
+            // This ensures wormhole pairs show connection lines on the stellar map
+            chunkManager.markObjectDiscovered(betaWormhole);
         }
         
         // CRITICAL: Reset animation state to prevent rendering corruption


### PR DESCRIPTION
When beta wormholes are created during traversal, they inherit the discovered state from their alpha twin but were not being added to the ChunkManager's discovery database. This caused the stellar map to not show connection lines between wormhole pairs.

The stellar map requires both wormholes to be in the discovered database (not just have discovered=true) to render connection lines.

- Add chunkManager.markObjectDiscovered() call for discovered beta wormholes
- This ensures wormhole pairs appear connected on the stellar map
- Maintains existing functionality while fixing visualization