### PR TITLE
fix(stellar-map): complete wormhole clickability implementation

### DIFF
--- a/src/game.ts
+++ b/src/game.ts
@@ -331,7 +331,7 @@ export class Game {
         // Always update hover state when stellar map is visible (for cursor feedback)
         if (this.stellarMap.isVisible()) {
             const discovered = this.getDiscoveredObjects();
-            this.stellarMap.detectHoverTarget(this.input.getMouseX(), this.input.getMouseY(), this.renderer.canvas, discovered.stars, discovered.planets, discovered.nebulae, discovered.asteroidGardens, discovered.blackHoles);
+            this.stellarMap.detectHoverTarget(this.input.getMouseX(), this.input.getMouseY(), this.renderer.canvas, discovered.stars, discovered.planets, discovered.nebulae, discovered.wormholes, discovered.asteroidGardens, discovered.blackHoles);
         } else {
             // Reset cursor when map is not visible
             this.stellarMap.updateCursor(this.renderer.canvas);

--- a/src/services/StateManager.ts
+++ b/src/services/StateManager.ts
@@ -260,7 +260,9 @@ export class StateManager {
             
             // CRITICAL FIX: Add beta wormhole to discovery database so it appears on stellar map
             // This ensures wormhole pairs show connection lines on the stellar map
-            chunkManager.markObjectDiscovered(betaWormhole);
+            // Generate proper wormhole name for discovery database
+            const betaWormholeName = `${betaWormhole.wormholeId}-${betaWormhole.designation === 'alpha' ? 'α' : 'β'}`;
+            chunkManager.markObjectDiscovered(betaWormhole, betaWormholeName);
         }
         
         // CRITICAL: Reset animation state to prevent rendering corruption


### PR DESCRIPTION
Fixed GitHub issue #98 - wormholes now fully clickable on stellar map.

Changes:
- Added missing wormhole info panel with detailed information
- Fixed missing wormhole hover detection in detectHoverTarget
- Added wormhole parameter to game.ts hover detection call
- Fixed beta wormhole naming in discovery database
- Added proper wormhole priority in hover state logic

Info panel displays:
- Wormhole designation (proper α/β naming)
- Type and designation details
- Twin wormhole coordinates
- Current position
- Wormhole ID
- Discovery timestamp

Wormholes now have proper cursor hover feedback and show detailed info panels when clicked, just like other objects.

Resolves #98