### PR TITLE
refactor: registry pattern for per-type chunk object generators

### DIFF
--- a/src/world/ChunkGenerator.ts
+++ b/src/world/ChunkGenerator.ts
@@ -37,11 +37,75 @@ interface CompanionWeight {
     weight: number;
 }
 
+// A registered generator for one celestial object type, run for every newly
+// generated chunk after the star-system core. Each built-in generator derives
+// its own seed from the chunk position, so one type's output never depends on
+// another's RNG state. Plugins can register additional types.
+export interface ChunkObjectGenerator {
+    name: string;
+    generate(chunkX: number, chunkY: number, chunk: Chunk): void;
+}
+
 export class ChunkGenerator {
     private world: WorldContext;
+    private objectGenerators: ChunkObjectGenerator[] = [];
 
     constructor(world: WorldContext) {
         this.world = world;
+        this.registerDefaultObjectGenerators();
+    }
+
+    // The built-in celestial object types, in their original generation order
+    private registerDefaultObjectGenerators(): void {
+        this.registerObjectGenerator({
+            name: 'nebulae',
+            generate: (chunkX, chunkY, chunk) => this.generateNebulaeForChunk(chunkX, chunkY, chunk)
+        });
+        this.registerObjectGenerator({
+            name: 'asteroidGardens',
+            generate: (chunkX, chunkY, chunk) => this.generateAsteroidGardensForChunk(chunkX, chunkY, chunk)
+        });
+        this.registerObjectGenerator({
+            name: 'wormholes',
+            generate: (chunkX, chunkY, chunk) => {
+                // Place pending wormhole pairs first; only generate new wormholes
+                // if no pending pair landed in this chunk
+                this.placePendingWormholePairs(chunkX, chunkY, chunk);
+                if (chunk.wormholes.length === 0) {
+                    this.generateWormholesForChunk(chunkX, chunkY, chunk);
+                }
+            }
+        });
+        this.registerObjectGenerator({
+            name: 'blackHoles',
+            generate: (chunkX, chunkY, chunk) => this.generateBlackHolesForChunk(chunkX, chunkY, chunk)
+        });
+        this.registerObjectGenerator({
+            name: 'roguePlanets',
+            generate: (chunkX, chunkY, chunk) => this.generateRoguePlanetsForChunk(chunkX, chunkY, chunk)
+        });
+        this.registerObjectGenerator({
+            name: 'darkNebulae',
+            generate: (chunkX, chunkY, chunk) => this.generateDarkNebulaeForChunk(chunkX, chunkY, chunk)
+        });
+        this.registerObjectGenerator({
+            name: 'crystalGardens',
+            generate: (chunkX, chunkY, chunk) => this.generateCrystalGardensForChunk(chunkX, chunkY, chunk)
+        });
+        this.registerObjectGenerator({
+            name: 'protostars',
+            generate: (chunkX, chunkY, chunk) => this.generateProtostarsForChunk(chunkX, chunkY, chunk)
+        });
+    }
+
+    // Extension point: plugins add new celestial object types here. Generators
+    // run for every newly generated chunk, after core star-system generation.
+    registerObjectGenerator(generator: ChunkObjectGenerator): void {
+        this.objectGenerators.push(generator);
+    }
+
+    get registeredObjectGenerators(): string[] {
+        return this.objectGenerators.map(g => g.name);
     }
 
     // Accessor mirrors: the generation code below was moved verbatim from
@@ -304,28 +368,10 @@ export class ChunkGenerator {
             this.generateCometsForStarSystem(star, starSystemRng, chunk, regionSpawnRates.comets);
         }
 
-        // Generate nebulae for this chunk (separate from star systems)
-        this.generateNebulaeForChunk(chunkX, chunkY, chunk);
-        
-        // Generate asteroid gardens for this chunk
-        this.generateAsteroidGardensForChunk(chunkX, chunkY, chunk);
-        
-        // Check for pending wormhole pairs that should be placed in this chunk FIRST
-        this.placePendingWormholePairs(chunkX, chunkY, chunk);
-        
-        // Generate new wormholes for this chunk (extremely rare) - only if no pending pairs were placed
-        if (chunk.wormholes.length === 0) {
-            this.generateWormholesForChunk(chunkX, chunkY, chunk);
+        // Run the registered per-type object generators in order
+        for (const generator of this.objectGenerators) {
+            generator.generate(chunkX, chunkY, chunk);
         }
-        
-        // Generate black holes for this chunk (ultra-rare - cosmic reset points)
-        this.generateBlackHolesForChunk(chunkX, chunkY, chunk);
-
-        // Generate region-specific objects for this chunk
-        this.generateRoguePlanetsForChunk(chunkX, chunkY, chunk);
-        this.generateDarkNebulaeForChunk(chunkX, chunkY, chunk);
-        this.generateCrystalGardensForChunk(chunkX, chunkY, chunk);
-        this.generateProtostarsForChunk(chunkX, chunkY, chunk);
 
         this.activeChunks.set(chunkKey, chunk);
         return chunk;

--- a/tests/world/chunkgenerator.test.js
+++ b/tests/world/chunkgenerator.test.js
@@ -39,6 +39,52 @@ describe('Chunk generation determinism', () => {
         expect(second).toBe(first);
     });
 
+    it('should run registered object generators in the original generation order', () => {
+        const manager = new ChunkManager();
+
+        expect(manager.generator.registeredObjectGenerators).toEqual([
+            'nebulae',
+            'asteroidGardens',
+            'wormholes',
+            'blackHoles',
+            'roguePlanets',
+            'darkNebulae',
+            'crystalGardens',
+            'protostars'
+        ]);
+    });
+
+    it('should invoke a custom registered generator for each newly generated chunk', () => {
+        const manager = new ChunkManager();
+        const calls = [];
+        manager.generator.registerObjectGenerator({
+            name: 'test-objects',
+            generate: (chunkX, chunkY, chunk) => calls.push({ chunkX, chunkY, chunk })
+        });
+
+        const chunk = manager.generateChunk(4, 5);
+
+        // Wormhole generation can recursively create a remote chunk, so assert
+        // on the call for this chunk specifically
+        const callForChunk = calls.filter(c => c.chunkX === 4 && c.chunkY === 5);
+        expect(callForChunk).toHaveLength(1);
+        expect(callForChunk[0].chunk).toBe(chunk);
+    });
+
+    it('should not re-run object generators for cached chunks', () => {
+        const manager = new ChunkManager();
+        const seen = [];
+        manager.generator.registerObjectGenerator({
+            name: 'counter',
+            generate: (chunkX, chunkY) => seen.push(`${chunkX},${chunkY}`)
+        });
+
+        manager.generateChunk(6, 6);
+        manager.generateChunk(6, 6);
+
+        expect(seen.filter(key => key === '6,6')).toHaveLength(1);
+    });
+
     it('should generate at least one star system across a region of chunks', () => {
         // Guards against a refactor accidentally short-circuiting generation:
         // with ~8% star system chance per chunk, 100 chunks virtually always


### PR DESCRIPTION
## Summary
The one-registration payoff for the ChunkManager breakdown (#148-#150): the hardcoded sequence of `generateXForChunk()` calls in `ChunkGenerator.generate()` becomes an ordered registry of `ChunkObjectGenerator` entries.

- New `registerObjectGenerator({ name, generate })` is the formal extension point — a plugin adds a celestial object type with one registration, and it runs for every newly generated chunk after core star-system generation
- The eight built-in types register in their original order; the wormhole entry keeps the pending-pair-placement-first and only-generate-if-empty rules intact
- Each built-in generator derives its own seed from chunk position, so no type''s output depends on another''s RNG state — registration order affects nothing but execution sequence, which is preserved anyway

## Testing
- 3 new registry contract tests (built-in order, custom generator invoked exactly once per new chunk — tolerant of deterministic wormhole recursion — and no re-runs on cached chunks), written first, red -> green
- Existing determinism lock tests confirm generation output is byte-identical
- `npm run build` clean; `npm test`: **1,828 passed**; lint totals unchanged from main