### PR TITLE
fix: resolve 7 pre-existing ESLint errors

### DIFF
--- a/src/game.ts
+++ b/src/game.ts
@@ -228,7 +228,7 @@ export class Game {
                         ...activeObjects.roguePlanets,
                         ...activeObjects.darkNebulae,
                         ...activeObjects.protostars
-                    ].filter(obj => obj.hasOwnProperty('discovered'));
+                    ].filter(obj => Object.prototype.hasOwnProperty.call(obj, 'discovered'));
                     this.chunkManager.restoreDiscoveryState(flattenedObjects);
                     
                     // Center stellar map on loaded position
@@ -1071,7 +1071,7 @@ export class Game {
                 ...activeObjects.roguePlanets,
                 ...activeObjects.darkNebulae,
                 ...activeObjects.protostars
-            ].filter(obj => obj.hasOwnProperty('discovered'));
+            ].filter(obj => Object.prototype.hasOwnProperty.call(obj, 'discovered'));
             this.chunkManager.restoreDiscoveryState(flattenedObjects);
 
             // Center stellar map on loaded position

--- a/src/services/SaveLoadService.ts
+++ b/src/services/SaveLoadService.ts
@@ -233,7 +233,8 @@ export class SaveLoadService {
 
         // Check required top-level properties - all must exist
         if (!data.version || !data.timestamp || !data.player || !data.world ||
-            !data.hasOwnProperty('discoveries') || !data.hasOwnProperty('discoveredObjects')) {
+            !Object.prototype.hasOwnProperty.call(data, 'discoveries') ||
+            !Object.prototype.hasOwnProperty.call(data, 'discoveredObjects')) {
             console.log('Validation failed: missing required properties', JSON.stringify(data));
             return false;
         }

--- a/src/services/SettingsService.ts
+++ b/src/services/SettingsService.ts
@@ -100,7 +100,6 @@ export class SettingsService {
                 
                 // Sync initial state with audio service
                 this.syncWithAudioService();
-            } else {
             }
         } catch (error) {
             console.warn('Failed to load settings, using defaults:', error);

--- a/src/services/StorageService.ts
+++ b/src/services/StorageService.ts
@@ -84,7 +84,7 @@ export class StorageService implements IStorageService {
             const storageData = JSON.parse(stored);
             
             // Validate storage data structure
-            if (!storageData || typeof storageData !== 'object' || !storageData.hasOwnProperty('data')) {
+            if (!storageData || typeof storageData !== 'object' || !Object.prototype.hasOwnProperty.call(storageData, 'data')) {
                 return { success: false, error: 'Invalid storage data format' };
             }
 

--- a/src/ui/SettingsMenu.ts
+++ b/src/ui/SettingsMenu.ts
@@ -522,7 +522,6 @@ export class SettingsMenu {
             ctx.lineTo(x + size/2, y + size - 4);
             ctx.lineTo(x + size - 4, y + 4);
             ctx.stroke();
-        } else {
         }
     }
 


### PR DESCRIPTION
## Summary
Fixes the 7 pre-existing ESLint errors (0 warnings touched) so `npm run lint` reports no errors:

- **no-prototype-builtins** (5): replaced direct `obj.hasOwnProperty(...)` calls with `Object.prototype.hasOwnProperty.call(obj, ...)` in `src/game.ts` (2), `src/services/SaveLoadService.ts` (2), and `src/services/StorageService.ts` (1)
- **no-empty** (2): removed empty `else {}` blocks in `src/services/SettingsService.ts` and `src/ui/SettingsMenu.ts`

No behavior changes.

## Validation
- `npm run build` — passes
- `npm test` — 1828 tests pass (79 files)
- `npx eslint src/**/*.ts --quiet` — 0 errors