### PR TITLE
chore: eliminate all no-unused-vars lint warnings (85 -> 0)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -12,7 +12,11 @@ export default tseslint.config(
     rules: {
       // Relax strict rules for migration period
       '@typescript-eslint/no-explicit-any': 'warn',
-      '@typescript-eslint/no-unused-vars': 'warn',
+      '@typescript-eslint/no-unused-vars': ['warn', {
+        argsIgnorePattern: '^_',
+        varsIgnorePattern: '^_',
+        caughtErrorsIgnorePattern: '^_'
+      }],
       
       // Keep these rules active for code quality
       'no-console': 'off', // Allow console for game logging

--- a/src/audio/soundmanager.ts
+++ b/src/audio/soundmanager.ts
@@ -1440,7 +1440,7 @@ export class SoundManager {
     /**
      * Smooth volume updates for organic evolution
      */
-    private updateLayerVolume(layer: any, currentTime: number): void {
+    private updateLayerVolume(_layer: any, _currentTime: number): void {
         // This method can add micro-variations or smooth interpolation if needed
         // Currently the linearRampToValueAtTime handles the volume changes
     }
@@ -1867,7 +1867,7 @@ export class SoundManager {
             for (const layer of this.ambientLayers) {
                 try {
                     layer.oscillator.stop();
-                } catch (error) {
+                } catch {
                     // Oscillator might already be stopped, ignore error
                 }
             }
@@ -1877,7 +1877,7 @@ export class SoundManager {
                 for (const note of this.melodicState.currentSequence) {
                     try {
                         note.oscillator.stop();
-                    } catch (error) {
+                    } catch {
                         // Oscillator might already be stopped, ignore error
                     }
                 }

--- a/src/camera/camera.ts
+++ b/src/camera/camera.ts
@@ -2,15 +2,6 @@
 import { Input } from '../input/input.js';
 
 // Type definitions
-interface CelestialObject {
-    x: number;
-    y: number;
-    type: string;
-    distanceToShip(camera: Camera): number;
-    brakingDistance?: number;
-    discoveryDistance: number;
-}
-
 interface StellarMap {
     isVisible(): boolean;
 }
@@ -71,7 +62,7 @@ export class Camera {
         this.loadDistanceTraveled();
     }
 
-    update(input: CameraInput, deltaTime: number, canvasWidth: number, canvasHeight: number, celestialObjects: any[] = [], stellarMap: StellarMap | null = null): void {
+    update(input: CameraInput, deltaTime: number, canvasWidth: number, canvasHeight: number, celestialObjects: any[] = [], _stellarMap: StellarMap | null = null): void {
         // Skip movement input processing if input has been consumed by UI elements (like settings menu)
         if (input.isTouchConsumed && input.isTouchConsumed()) {
             // Still update position from existing velocity but don't process new input

--- a/src/debug/CommandRegistry.ts
+++ b/src/debug/CommandRegistry.ts
@@ -186,7 +186,7 @@ export class CommandRegistry {
             parameters: [
                 { name: 'command', type: 'string', optional: true, description: 'Command to get help for' }
             ],
-            execute: (params: string[], context: CommandContext) => {
+            execute: (params: string[], _context: CommandContext) => {
                 if (params.length === 0) {
                     this.showGeneralHelp();
                 } else {
@@ -209,7 +209,7 @@ export class CommandRegistry {
                   values: ['star', 'planet', 'nebula', 'asteroid', 'blackhole', 'comet', 'rogue-planet', 'dark-nebula', 'crystal-garden', 'wormhole'],
                   description: 'Object type to list variants for' }
             ],
-            execute: (params: string[], context: CommandContext) => {
+            execute: (params: string[], _context: CommandContext) => {
                 this.showObjectTypesList(params[0]);
             },
             autocomplete: (partial: string) => {
@@ -285,7 +285,7 @@ export class CommandRegistry {
                   values: ['true', 'false'],
                   description: 'Value to set (true/false)' }
             ],
-            execute: (params: string[], context: CommandContext) => {
+            execute: (params: string[], _context: CommandContext) => {
                 this.setSetting(params[0], params[1]);
             },
             autocomplete: (partial: string) => {
@@ -445,7 +445,7 @@ export class CommandRegistry {
         
         if (clearAll) {
             // Clear debug objects from all loaded chunks
-            for (const [chunkKey, chunk] of chunkManager.activeChunks) {
+            for (const [chunkKey] of chunkManager.activeChunks) {
                 if (chunkManager.debugObjects) {
                     const beforeCount = chunkManager.debugObjects.length;
                     chunkManager.debugObjects = chunkManager.debugObjects.filter(obj => {
@@ -483,8 +483,7 @@ export class CommandRegistry {
         
         const objectType = params[0];
         const variant = params[1] || null;
-        const distance = params[2] ? parseFloat(params[2]) : null;
-        
+
         // Use imported DebugSpawner
         
         try {

--- a/src/debug/ErrorTestingCommands.ts
+++ b/src/debug/ErrorTestingCommands.ts
@@ -2,7 +2,7 @@
 // Used to validate error recovery mechanisms and logging
 
 import { getErrorService } from '../services/ErrorService.js';
-import { getLogger, LogLevel } from '../services/LoggerService.js';
+import { getLogger } from '../services/LoggerService.js';
 import { UIErrorBoundary } from '../ui/UIErrorBoundary.js';
 
 export interface ErrorTestScenario {

--- a/src/debug/SeedInspectorService.ts
+++ b/src/debug/SeedInspectorService.ts
@@ -6,7 +6,7 @@
  * @since 0.1.0
  */
 
-import { SeededRandom, hashPosition, setUniverseSeed, getUniverseSeed } from '../utils/random.js';
+import { setUniverseSeed, getUniverseSeed } from '../utils/random.js';
 import type { ChunkManager } from '../world/ChunkManager.js';
 
 /**

--- a/src/debug/debug-spawner.ts
+++ b/src/debug/debug-spawner.ts
@@ -2,7 +2,7 @@
 // This file should be completely excluded from production builds
 
 import { SeededRandom } from '../utils/random.js';
-import { generateWormholePair, Wormhole } from '../celestial/wormholes.js';
+import { generateWormholePair } from '../celestial/wormholes.js';
 import { generateBlackHole, BlackHole, BlackHoleTypes } from '../celestial/blackholes.js';
 import { Star, Planet, StarTypes, PlanetTypes } from '../celestial/celestial.js';
 import { Nebula, selectNebulaType } from '../celestial/nebulae.js';

--- a/src/game.ts
+++ b/src/game.ts
@@ -16,11 +16,10 @@ import { NamingService } from './naming/naming.js';
 import { TouchUI } from './ui/touchui.js';
 import { SoundManager } from './audio/soundmanager.js';
 import { SimplifiedDiscoveryService } from './services/SimplifiedDiscoveryService.js';
-import { createDiscoveryService } from './services/DiscoveryServiceFactory.js';
 import { StateManager } from './services/StateManager.js';
 import { DebugSpawner } from './debug/debug-spawner.js';
 import { DeveloperConsole } from './debug/DeveloperConsole.js';
-import { createGameComponents, GameComponents } from './services/GameFactory.js';
+import { createGameComponents } from './services/GameFactory.js';
 import { CommandRegistry } from './debug/CommandRegistry.js';
 import { AudioService } from './services/AudioService.js';
 import { SettingsService } from './services/SettingsService.js';
@@ -931,7 +930,7 @@ export class Game {
             if (regionInfo && regionInfo.definition && regionInfo.influence > 0.3) {
                 return regionInfo.regionType;
             }
-        } catch (error) {
+        } catch {
             // Silently handle region lookup errors
         }
         return undefined;

--- a/src/graphics/GameRenderer.ts
+++ b/src/graphics/GameRenderer.ts
@@ -49,7 +49,7 @@ export class GameRenderer {
         const activeObjects = this.cachedActiveObjects || this.chunkManager.getAllActiveObjects();
         
         // Performance optimization: Calculate screen bounds for render culling
-        const screenBounds = this.calculateScreenBounds();
+        const _screenBounds = this.calculateScreenBounds();
         
         // Render nebulae first (background layer) - with culling disabled for now
         for (const obj of activeObjects.nebulae) {

--- a/src/services/AudioService.ts
+++ b/src/services/AudioService.ts
@@ -41,7 +41,7 @@ export class AudioService {
                 if (this.soundManager.setVolume) {
                     this.soundManager.setVolume('master', volume);
                 }
-            } catch (error) {
+            } catch {
                 // Ignore sound manager errors gracefully
             }
             this.saveSettings();
@@ -89,7 +89,7 @@ export class AudioService {
                 } else if (objectType === 'crystal-garden') {
                     this.soundManager.playCrystalGardenDiscovery('pure');
                 }
-            } catch (error) {
+            } catch {
                 // Ignore sound manager errors gracefully
             }
         }
@@ -125,7 +125,7 @@ export class AudioService {
                 this.volume = settings.volume || 0.8;
                 this.muted = settings.muted || false;
             }
-        } catch (error) {
+        } catch {
             // Use defaults
         }
     }
@@ -134,7 +134,7 @@ export class AudioService {
         try {
             const settings = { volume: this.volume, muted: this.muted };
             localStorage.setItem('astralSurveyor_audioSettings', JSON.stringify(settings));
-        } catch (error) {
+        } catch {
             // Ignore save errors
         }
     }

--- a/src/services/ErrorBoundary.ts
+++ b/src/services/ErrorBoundary.ts
@@ -323,7 +323,7 @@ export class ErrorBoundary {
     /**
      * Handle graceful degradation based on error type
      */
-    handleGracefulDegradation(error: Error, service: string): GracefulDegradation {
+    handleGracefulDegradation(error: Error, _service: string): GracefulDegradation {
         const classification = this.classifyError(error);
 
         switch (classification.type) {

--- a/src/services/ErrorService.ts
+++ b/src/services/ErrorService.ts
@@ -69,7 +69,7 @@ export class ErrorService {
 
     // Backward compatibility stubs for deleted complex methods
     getDegradedServices(): string[] { return []; }
-    markServiceRecovered(service: string): void { /* simplified - no op */ }
+    markServiceRecovered(_service: string): void { /* simplified - no op */ }
     executeWithRetry<T>(
         service: string,
         operation: string,
@@ -85,7 +85,7 @@ export class ErrorService {
     }
     getHealthStatus(): any { return { status: 'healthy' }; }
     getRecentErrors(): any[] { return []; }
-    onServiceDegraded(callback: (data: ServiceDegradationData) => void): void { /* no op */ }
+    onServiceDegraded(_callback: (data: ServiceDegradationData) => void): void { /* no op */ }
 
     // Private method to log and emit errors
     private logError(service: string, operation: string, error: Error, userMessage?: string): void {

--- a/src/services/SaveLoadService.ts
+++ b/src/services/SaveLoadService.ts
@@ -34,7 +34,7 @@ export class SaveLoadService {
         private discoveryLogbook: DiscoveryLogbook,
         private chunkManager: ChunkManager,
         discoveryManager?: SimplifiedDiscoveryService,
-        settingsService?: any // Optional for backward compatibility
+        _settingsService?: any // Optional for backward compatibility
     ) {
         if (discoveryManager) {
             this.discoveryManager = discoveryManager;

--- a/src/services/StateManager.ts
+++ b/src/services/StateManager.ts
@@ -192,10 +192,7 @@ export class StateManager {
         const sourceWormhole = this.traversalDestination.wormhole;
         const destChunkX = Math.floor(camera.x / 2000);
         const destChunkY = Math.floor(camera.y / 2000);
-        
-        const betaChunkX = Math.floor(sourceWormhole.twinX / 2000);
-        const betaChunkY = Math.floor(sourceWormhole.twinY / 2000);
-        
+
         // Get or generate the destination chunk
         const destChunk = chunkManager.generateChunk(destChunkX, destChunkY);
         if (!destChunk) {
@@ -289,16 +286,11 @@ export class StateManager {
      */
     private cleanupDuplicateBetaWormholes(duplicateBetas: any[], chunkManager: any): void {
         // Keep the first one, remove the rest
-        const keepWormhole = duplicateBetas[0];
         const removeWormholes = duplicateBetas.slice(1);
-        
+
         // Get all chunks and remove duplicates from each chunk
-        let totalRemoved = 0;
-        
         for (const chunk of chunkManager.activeChunks.values()) {
             if (chunk.wormholes) {
-                const originalLength = chunk.wormholes.length;
-                
                 // Remove duplicates but keep the first occurrence
                 chunk.wormholes = chunk.wormholes.filter(w => {
                     if (removeWormholes.includes(w)) {
@@ -306,11 +298,6 @@ export class StateManager {
                     }
                     return true; // Keep this wormhole
                 });
-                
-                const removed = originalLength - chunk.wormholes.length;
-                if (removed > 0) {
-                    totalRemoved += removed;
-                }
             }
         }
     }

--- a/src/services/StorageService.ts
+++ b/src/services/StorageService.ts
@@ -173,7 +173,7 @@ export class StorageService implements IStorageService {
                 // localStorage typically has ~5-10MB limit, but we can't reliably detect it
                 quotaRemaining: undefined
             };
-        } catch (error) {
+        } catch {
             return { available: true }; // Available but couldn't calculate usage
         }
     }
@@ -193,7 +193,7 @@ export class StorageService implements IStorageService {
             localStorage.removeItem(testKey);
             
             return true;
-        } catch (error) {
+        } catch {
             return false;
         }
     }

--- a/src/ship/ship.ts
+++ b/src/ship/ship.ts
@@ -7,11 +7,6 @@ import type { Renderer } from '../graphics/renderer.js';
 import type { Camera } from '../camera/camera.js';
 
 // Interface definitions
-interface SpriteData {
-    sprite: string[];
-    colors: Record<string, string>;
-}
-
 interface StarLike {
     x: number;
     y: number;
@@ -257,7 +252,6 @@ export class StarParticles {
     update(deltaTime: number, stars: StarLike[], camera: Camera): void {
         // Spawn new particles for visible stars
         for (const star of stars) {
-            const [screenX, screenY] = camera.worldToScreen(star.x, star.y, 9999, 9999); // Use large canvas size for distance check
             const distanceToCamera = Math.sqrt((star.x - camera.x) ** 2 + (star.y - camera.y) ** 2);
             
             // Only spawn particles for stars that are reasonably close

--- a/src/ui/StellarMap.ts
+++ b/src/ui/StellarMap.ts
@@ -8,7 +8,6 @@ import type { Input } from '../input/input.js';
 import { NamingService } from '../naming/naming.js';
 import type { SeedInspectorService, CelestialObjectData } from '../debug/SeedInspectorService.js';
 import type { ChunkManager } from '../world/ChunkManager.js';
-import { GameConstants } from '../config/GameConstants.js';
 import { StarRenderer } from './stellarmap/renderers/StarRenderer.js';
 import { PlanetRenderer } from './stellarmap/renderers/PlanetRenderer.js';
 import { NebulaRenderer } from './stellarmap/renderers/NebulaRenderer.js';
@@ -23,7 +22,7 @@ import { DiscoveryVisualizationService } from '../services/DiscoveryVisualizatio
 import { InteractionController } from './stellarmap/InteractionController.js';
 import { InspectorModeController } from './stellarmap/InspectorModeController.js';
 import { GridRenderer } from './stellarmap/GridRenderer.js';
-import { MarkerRenderer, type GameStartingPosition as MarkerGameStartingPosition } from './stellarmap/MarkerRenderer.js';
+import { MarkerRenderer } from './stellarmap/MarkerRenderer.js';
 import { MapUIRenderer } from './stellarmap/MapUIRenderer.js';
 
 // Interface definitions
@@ -119,25 +118,6 @@ interface CometLike {
     timestamp?: number;
 }
 
-// Union type for all discoverable objects
-type DiscoverableObject = StarLike | PlanetLike | NebulaLike | WormholeLike | AsteroidGardenLike | BlackHoleLike | CometLike;
-
-// Centralized Hover System Interfaces
-interface HoverableObject {
-    type: string;
-    x: number;
-    y: number;
-    // Optional properties that may exist on different object types
-    radius?: number;
-    [key: string]: any; // Allow other properties
-}
-
-interface HoverConfig {
-    threshold: number;
-    renderSize: number;
-    priority: number; // Lower number = higher priority
-}
-
 // Selection System Interfaces
 /**
  * Configuration for celestial object selection behavior
@@ -178,98 +158,6 @@ interface ClosestObjectResult {
     type: string;
     priority: number;
     config: CelestialSelectionConfig;
-}
-
-class StellarMapHoverSystem {
-    private hoveredObject: HoverableObject | null = null;
-    private hoveredObjectType: string | null = null;
-
-    private readonly hoverConfigs: Record<string, HoverConfig> = {
-        'planet': { threshold: 15, renderSize: 3, priority: 1 },
-        'rogue-planet': { threshold: 15, renderSize: 3, priority: 2 },
-        'dark-nebula': { threshold: 18, renderSize: 4, priority: 3 },
-        'protostar': { threshold: 20, renderSize: 5, priority: 3.5 },
-        'crystal-garden': { threshold: 16, renderSize: 4, priority: 4 },
-        'nebula': { threshold: 20, renderSize: 5, priority: 5 },
-        'wormhole': { threshold: 12, renderSize: 3, priority: 6 },
-        'comet': { threshold: 12, renderSize: 2, priority: 7 },
-        'blackhole': { threshold: 15, renderSize: 4, priority: 8 },
-        'asteroidGarden': { threshold: 18, renderSize: 4, priority: 9 },
-        'celestialStar': { threshold: 10, renderSize: 2, priority: 10 }
-    };
-
-    detectHover(mouseX: number, mouseY: number, mapX: number, mapY: number, mapWidth: number, mapHeight: number, 
-                worldToMapScale: number, centerX: number, centerY: number, objectCollections: Record<string, HoverableObject[]>): void {
-        
-        let closestObject: HoverableObject | null = null;
-        let closestDistance = Infinity;
-        let closestType: string | null = null;
-
-        // Check all object collections in priority order
-        const sortedTypes = Object.keys(this.hoverConfigs).sort((a, b) => 
-            this.hoverConfigs[a].priority - this.hoverConfigs[b].priority
-        );
-
-        for (const objectType of sortedTypes) {
-            const objects = objectCollections[objectType];
-            if (!objects || objects.length === 0) continue;
-
-            const config = this.hoverConfigs[objectType];
-
-            for (const obj of objects) {
-                const objMapX = mapX + mapWidth/2 + (obj.x - centerX) * worldToMapScale;
-                const objMapY = mapY + mapHeight/2 + (obj.y - centerY) * worldToMapScale;
-
-                // Check if object is within map bounds
-                if (objMapX >= mapX && objMapX <= mapX + mapWidth && 
-                    objMapY >= mapY && objMapY <= mapY + mapHeight) {
-                    
-                    const distance = Math.sqrt((mouseX - objMapX)**2 + (mouseY - objMapY)**2);
-                    if (distance <= config.threshold && distance < closestDistance) {
-                        closestObject = obj;
-                        closestDistance = distance;
-                        closestType = objectType;
-                    }
-                }
-            }
-
-            // If we found something at this priority level, stop searching lower priorities
-            if (closestObject) break;
-        }
-
-        this.hoveredObject = closestObject;
-        this.hoveredObjectType = closestType;
-    }
-
-    getHoveredObject(): { object: HoverableObject | null, type: string | null } {
-        return { object: this.hoveredObject, type: this.hoveredObjectType };
-    }
-
-    clearHover(): void {
-        this.hoveredObject = null;
-        this.hoveredObjectType = null;
-    }
-
-    renderHoverEffect(ctx: CanvasRenderingContext2D, mapX: number, mapY: number, mapWidth: number, mapHeight: number, 
-                     worldToMapScale: number, centerX: number, centerY: number): void {
-        if (!this.hoveredObject || !this.hoveredObjectType) return;
-
-        const config = this.hoverConfigs[this.hoveredObjectType];
-        if (!config) return;
-
-        const objMapX = mapX + mapWidth/2 + (this.hoveredObject.x - centerX) * worldToMapScale;
-        const objMapY = mapY + mapHeight/2 + (this.hoveredObject.y - centerY) * worldToMapScale;
-
-        // Render hover effect (consistent with existing object hover styles)
-        ctx.save();
-        ctx.strokeStyle = '#d4a57480'; // Semi-transparent amber like other objects (currentPositionColor + '80')
-        ctx.lineWidth = 1;
-        ctx.beginPath();
-        const hoverRadius = Math.max(5, config.renderSize + 1);
-        ctx.arc(objMapX, objMapY, hoverRadius, 0, Math.PI * 2);
-        ctx.stroke();
-        ctx.restore();
-    }
 }
 
 /**
@@ -1675,7 +1563,7 @@ export class StellarMap {
     /**
      * Render statistics overlay showing object counts, density, and region info
      */
-    private renderStatisticsOverlay(ctx: CanvasRenderingContext2D, mapX: number, mapY: number, mapWidth: number, mapHeight: number): void {
+    private renderStatisticsOverlay(ctx: CanvasRenderingContext2D, mapX: number, mapY: number, _mapWidth: number, _mapHeight: number): void {
         if (!this.statisticsOverlayEnabled || !this.currentViewStatistics) return;
 
         ctx.save();

--- a/src/ui/UIErrorBoundary.ts
+++ b/src/ui/UIErrorBoundary.ts
@@ -1,7 +1,7 @@
 // UI Error Boundary - Handles UI component errors with graceful degradation
 // Provides user-friendly error messages and fallback UI when components fail
 
-import { ErrorService, ErrorEvents, ErrorEventData, ServiceDegradationData } from '../services/ErrorService.js';
+import { ErrorService, ErrorEventData, ServiceDegradationData } from '../services/ErrorService.js';
 import { GameConfig } from '../config/gameConfig.js';
 
 export interface UIErrorState {

--- a/src/ui/discoverylogbook.ts
+++ b/src/ui/discoverylogbook.ts
@@ -7,7 +7,7 @@ import type { Camera } from '../camera/camera.js';
 import type { Input } from '../input/input.js';
 import type { SimplifiedDiscoveryService } from '../services/SimplifiedDiscoveryService.js';
 import type { DiscoveryEntry } from '../services/ObjectDiscovery.js';
-import type { DiscoveryFilter, DiscoveryCategory, DiscoveryStatistics } from '../services/DiscoveryStats.js';
+import type { DiscoveryStatistics } from '../services/DiscoveryStats.js';
 import type { DiscoveryDisplay } from './ui.js';
 
 // Legacy interface for backward compatibility
@@ -25,8 +25,6 @@ interface DiscoveryData {
 }
 
 // UI state interfaces
-type SortField = 'timestamp' | 'name' | 'type' | 'rarity';
-type SortDirection = 'asc' | 'desc';
 type ViewMode = 'list' | 'detail';
 
 interface UIState {
@@ -264,7 +262,6 @@ export class DiscoveryLogbook {
             return;
         }
 
-        const panelX = canvasWidth - this.panelWidth - 20;
         const panelY = 80;
 
         if (this.uiState.viewMode === 'detail') {
@@ -301,10 +298,10 @@ export class DiscoveryLogbook {
     // Check if mouse coordinates are over the logbook panel
     isMouseOver(mouseX: number, mouseY: number, canvasWidth: number, _canvasHeight: number): boolean {
         if (!this.visible) return false;
-        
+
         const panelX = canvasWidth - this.panelWidth - 20;
         const panelY = 80;
-        
+
         return mouseX >= panelX && mouseX <= panelX + this.panelWidth &&
                mouseY >= panelY && mouseY <= panelY + this.panelHeight;
     }
@@ -799,10 +796,9 @@ export class DiscoveryLogbook {
     /**
      * Handle mouse clicks for interactive elements
      */
-    handleClick(mouseX: number, mouseY: number, canvasWidth: number, canvasHeight: number, camera?: Camera): boolean {
+    handleClick(mouseX: number, mouseY: number, canvasWidth: number, canvasHeight: number, _camera?: Camera): boolean {
         if (!this.visible) return false;
         
-        const panelX = canvasWidth - this.panelWidth - 20;
         const panelY = 80;
         
         // Check if click is within panel

--- a/src/ui/minimap.ts
+++ b/src/ui/minimap.ts
@@ -80,7 +80,7 @@ export class LocalMinimap {
     /**
      * Update minimap state - refresh object positions for orbital movement
      */
-    update(deltaTime: number): void {
+    update(_deltaTime: number): void {
         // The minimap data is refreshed each render cycle, so orbital movement
         // should automatically be reflected. No additional state tracking needed.
     }
@@ -88,7 +88,7 @@ export class LocalMinimap {
     /**
      * Get minimap bounds for click detection
      */
-    getBounds(canvasWidth: number, canvasHeight: number): { x: number; y: number; width: number; height: number } {
+    getBounds(_canvasWidth: number, _canvasHeight: number): { x: number; y: number; width: number; height: number } {
         return {
             x: this.padding,
             y: this.padding + this.topOffset,
@@ -103,7 +103,7 @@ export class LocalMinimap {
     render(renderer: Renderer, camera: Camera): void {
         if (!this.visible) return;
         
-        const { canvas, ctx } = renderer;
+        const { ctx } = renderer;
         
         // Save context state
         ctx.save();
@@ -300,9 +300,6 @@ export class LocalMinimap {
         // Get player's current chunk coordinates
         const playerChunkCoords = this.chunkManager.getChunkCoords(camera.x, camera.y);
         
-        let totalObjects = 0;
-        let processedChunks = 0;
-        
         // Query all chunks within radius (like seed inspector)
         for (let chunkX = playerChunkCoords.x - this.chunkRadius; chunkX <= playerChunkCoords.x + this.chunkRadius; chunkX++) {
             for (let chunkY = playerChunkCoords.y - this.chunkRadius; chunkY <= playerChunkCoords.y + this.chunkRadius; chunkY++) {
@@ -314,8 +311,6 @@ export class LocalMinimap {
                 const chunk = this.chunkManager.getChunk(chunkKey);
                 
                 if (chunk) {
-                    processedChunks++;
-                    
                     // Process all object types in this chunk
                     this.processChunkObjects(chunk.celestialStars, 'star', objects, camera);
                     this.processChunkObjects(chunk.planets, 'planet', objects, camera);
@@ -329,16 +324,10 @@ export class LocalMinimap {
                     this.processChunkObjects(chunk.darkNebulae, 'dark-nebula', objects, camera);
                     this.processChunkObjects(chunk.crystalGardens, 'crystal-garden', objects, camera);
                     this.processChunkObjects(chunk.protostars, 'protostar', objects, camera);
-                    
-                    totalObjects += Object.values(chunk).reduce((sum, arr) => {
-                        return sum + (Array.isArray(arr) ? arr.length : 0);
-                    }, 0);
                 }
             }
         }
-        
-        // Debug logging can be uncommented if needed for troubleshooting
-        // console.log(`Minimap: Scanned ${processedChunks} chunks, found ${totalObjects} total objects, showing ${objects.length} on minimap`);
+
         return objects;
     }
     
@@ -349,8 +338,8 @@ export class LocalMinimap {
     private processChunkObjects(
         objectArray: any[], 
         type: DetectableObject['type'], 
-        result: DetectableObject[], 
-        camera: Camera
+        result: DetectableObject[],
+        _camera: Camera
     ): void {
         if (!objectArray || objectArray.length === 0) return;
         

--- a/src/ui/stellarmap/renderers/CometRenderer.ts
+++ b/src/ui/stellarmap/renderers/CometRenderer.ts
@@ -91,7 +91,7 @@ export class CometRenderer extends BaseRenderer {
         ctx: CanvasRenderingContext2D,
         comet: CometLike,
         context: MapRenderContext,
-        zoomLevel: number
+        _zoomLevel: number
     ): void {
         if (!comet.parentStarX || !comet.parentStarY) return;
 

--- a/src/ui/stellarmap/renderers/PlanetRenderer.ts
+++ b/src/ui/stellarmap/renderers/PlanetRenderer.ts
@@ -24,7 +24,7 @@ export class PlanetRenderer extends BaseRenderer {
     ): void {
         if (!discoveredPlanets) return;
 
-        const { ctx, mapX, mapY, mapWidth, mapHeight, worldToMapScale, centerX, centerY } = context;
+        const { ctx, mapX, mapY, mapWidth, mapHeight, worldToMapScale } = context;
 
         // Group planets by their parent star for orbital rendering
         const planetsByStarId = new Map<string, PlanetLike[]>();
@@ -99,8 +99,6 @@ export class PlanetRenderer extends BaseRenderer {
         planets: PlanetLike[],
         context: MapRenderContext
     ): void {
-        const { mapX, mapY, mapWidth, mapHeight, centerX, centerY, worldToMapScale } = context;
-
         // Calculate unique orbital radii for this star system based on actual map positions
         const orbitalRadii = new Set<number>();
 

--- a/src/ui/ui.ts
+++ b/src/ui/ui.ts
@@ -224,7 +224,7 @@ export class DiscoveryDisplay {
                 if (regionInfo && regionInfo.definition) {
                     regionText = this.getRegionDescription(regionInfo.definition.name, regionInfo.influence);
                 }
-            } catch (error) {
+            } catch {
                 // Silently handle any region lookup errors
                 regionText = '';
             }

--- a/src/world/ChunkGenerator.ts
+++ b/src/world/ChunkGenerator.ts
@@ -1151,7 +1151,7 @@ export class ChunkGenerator {
         }
     }
     
-    private generateWormholeId(chunkX: number, chunkY: number, rng: SeededRandom): string {
+    private generateWormholeId(chunkX: number, chunkY: number, _rng: SeededRandom): string {
         // Generate unique but predictable wormhole ID
         const baseId = Math.abs(hashPosition(chunkX, chunkY)) % 9999;
         return `WH-${baseId.toString().padStart(4, '0')}`;

--- a/src/world/InfiniteStarField.ts
+++ b/src/world/InfiniteStarField.ts
@@ -111,8 +111,6 @@ export class InfiniteStarField {
     }
 
     render(renderer: Renderer, camera: Camera): void {
-        const { canvas } = renderer;
-        
         // Render parallax background layers first (back to front)
         this.renderParallaxLayers(renderer, camera);
         

--- a/src/world/RegionGenerator.ts
+++ b/src/world/RegionGenerator.ts
@@ -184,7 +184,6 @@ export class RegionGenerator {
         const rng = new SeededRandom(macroSeed);
         
         const regionCenters: RegionPoint[] = [];
-        const regionTypes = Object.keys(CosmicRegionTypes);
         const macroAreaSize = REGION_CONFIG.macroAreaSize;
         const regionsToPlace = REGION_CONFIG.regionsPerMacroArea;
         


### PR DESCRIPTION
## Summary
Step 2 of the lint cleanup (follow-up to #153): clears every `@typescript-eslint/no-unused-vars` warning. Lint output drops from 307 warnings to 222 (all remaining are `no-explicit-any`, to be tackled per-domain later).

### Config
- `eslint.config.js`: added `argsIgnorePattern` / `varsIgnorePattern` / `caughtErrorsIgnorePattern: '^_'` so ESLint honors the underscore-prefix convention the codebase already uses (`_camera`, `_deltaTime`, ...). This alone cleared 14 warnings.

### Code (71 warnings, 25 files)
- **Deleted unused imports and type aliases** (`LogLevel`, `Wormhole`, `GameConstants`, `SortField`/`SortDirection`, etc.)
- **Removed dead code**: the `StellarMapHoverSystem` class in `src/ui/StellarMap.ts` (plus its orphaned `HoverableObject`/`HoverConfig`/`DiscoverableObject` types) was a leftover copy from the refactor that extracted it to `src/ui/stellarmap/StellarMapHoverSystem.ts` — the extracted version is the one in use. Also dropped never-read locals (`betaChunkX/Y`, `keepWormhole`, `totalRemoved`, debug counters in minimap, etc.)
- **Underscore-prefixed intentionally-unused params** (callback signatures, no-op stubs, backward-compat params)
- **Bare `catch` blocks** where the caught error was deliberately ignored

No behavior changes intended; all deletions are pure computations or dead code.

## Validation
- `npm run build` — passes
- `npm test` — 1828 tests pass (79 files)
- `npm run lint` — 0 errors, 0 `no-unused-vars`; 222 `no-explicit-any` warnings remain (out of scope)